### PR TITLE
Add a separate view for streaming chat responses from the Khoj service

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -138,7 +138,7 @@ WSGI_APPLICATION = "app.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "postgres",
+        "NAME": os.getenv("DB_NAME", "postgres"),
         "USER": "postgres",
         "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
         "HOST": os.environ.get("POSTGRES_HOST", "localhost"),

--- a/app/urls.py
+++ b/app/urls.py
@@ -24,6 +24,13 @@ urlpatterns = [
     path("beta/", include("beta_product.urls")),
     path("auth/", include("user_manager.urls")),
     path("token/", views.obtain_auth_token, name="token"),
+    re_path(
+        r"^api/chat/.*", include("khoj_service.api_urls"), name="khoj_service_chat"
+    ),
+    # api/chat/ is a special case, because the response needs to be streamed just for this endpoint.
+    re_path(
+        r"^api/chat.*", include("khoj_service.chat_urls"), name="khoj_service_chat"
+    ),
     re_path(r"^api/.*", include("khoj_service.api_urls"), name="khoj_service_api"),
     path("", include("khoj_service.urls"), name="khoj_service"),
 ]

--- a/khoj_service/chat_urls.py
+++ b/khoj_service/chat_urls.py
@@ -3,5 +3,5 @@ from khoj_service import views
 
 
 urlpatterns = [
-    path("", views.DefaultRedirectApiView.as_view()),
+    path("", views.StreamingApiView.as_view()),
 ]

--- a/khoj_service/constants.py
+++ b/khoj_service/constants.py
@@ -1,0 +1,3 @@
+from app.settings import DEBUG
+
+KHOJ_HOME = "http://localhost:3000" if DEBUG else "https://khoj.dev"

--- a/khoj_service/views.py
+++ b/khoj_service/views.py
@@ -5,6 +5,10 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework import status
 from khoj_service.models import RoutingTable
+from django.contrib.auth.models import AnonymousUser
+from django.shortcuts import redirect
+from django.http import StreamingHttpResponse
+from khoj_service.constants import KHOJ_HOME
 
 
 class DefaultRedirectApiView(APIView):
@@ -21,8 +25,7 @@ class DefaultRedirectApiView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
         khoj_response = requests.get(f"{service_url}{request_path}")
-        respond = HttpResponse(khoj_response)
-        return respond
+        return HttpResponse(khoj_response)
 
     def post(self, request):
         user = request.user
@@ -37,8 +40,41 @@ class DefaultRedirectApiView(APIView):
         khoj_response = requests.post(
             f"{service_url}{request_path}", json=body, headers=request.headers
         )
-        respond = HttpResponse(khoj_response)
-        return respond
+        return HttpResponse(khoj_response)
+
+
+class StreamingApiView(APIView):
+    permission_classes = [IsAuthenticated]
+    routing_table = RoutingTable.objects.all()
+
+    def _streaming_response(self, response):
+        aggregator = b""
+        for chunk in response.iter_content(100):
+            # This indicates that the compiled references are coming. We want to batch this response in a single chunk.
+            # Bear in mind it's possible that the compiled references indicator is split across two chunks. In this case, rendering will fail.
+            if (
+                len(aggregator) != 0
+                or str(chunk).find("### compiled references:") != -1
+            ):
+                aggregator += chunk
+                continue
+            yield chunk
+        yield aggregator
+
+    def get(self, request):
+        user = request.user
+        request_path = request.get_full_path()
+        service_url = self.routing_table.get_service_url_by_user(user)
+        if service_url is None:
+            return Response(
+                {"error": "user does not have a service with Khoj"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        response = requests.get(f"{service_url}{request_path}", stream=True)
+        return StreamingHttpResponse(
+            streaming_content=self._streaming_response(response),
+            content_type=response.headers["Content-Type"],
+        )
 
 
 class RedirectToKhojAncilliaryAssets(APIView):
@@ -60,11 +96,13 @@ class RedirectToKhojAncilliaryAssets(APIView):
 
 
 class RedirectToKhojHomePage(APIView):
-    permission_classes = [IsAuthenticated]
     routing_table = RoutingTable.objects.all()
 
     def get(self, request):
         user = request.user
+        if isinstance(user, AnonymousUser):
+            return redirect(f"{KHOJ_HOME}/login/")
+
         service_url = self.routing_table.get_service_url_by_user(user)
         if service_url is None:
             # TODO: We probably want to redirect to a Sign-Up page here.


### PR DESCRIPTION
# Incoming
- Add a default behavior to redirect if the user isn't logged in
- Stream the response for api/chat. Add custom support to route this url, as it doesn't seem to be working just as a re_path within the api_urls
- Add a constants file, which owns the URL for khoj home
- Pull the `DB_NAME` from environment variables

Addresses some issues in https://github.com/khoj-ai/lantern/issues/12 and assists with https://github.com/khoj-ai/khoj/issues/257